### PR TITLE
 Dodanie pliku gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.acn
+*.acr
+*.alg
+*.aux
+*.glg
+*.glo
+*.gls
+*.ist
+*.log
+*.out
+*.gz
+*.bbl
+*.blg
+*.toc


### PR DESCRIPTION
Tej PR dodaje plik git ignore, który wskazuje wzorce plików, które nie będą dołączane przy operacji git add. Powinno to ograniczyć (a docelowo wykluczyć) włączenie na repo plików pośrednik kompilacji LaTeX.